### PR TITLE
make sure attributes are strings

### DIFF
--- a/controls/postgres_spec.rb
+++ b/controls/postgres_spec.rb
@@ -50,7 +50,7 @@ POSTGRES_CONF_PATH = attribute(
   'postgres_conf_path',
   description: 'define path for the postgresql configuration file',
   default: postgres.conf_path
-)
+).to_s
 
 POSTGRES_HBA_CONF_FILE = attribute(
   'postgres_hba_conf_file',


### PR DESCRIPTION
This currently breaks inspec check when the default attribute isn't found and becomes nil.
```
Default postgresql configuration directory: does not exist. Postgresql may not be installed or we've misidentified the configuration directory.

Default postgresql data directory: does not exist. Postgresql may not be installed or we've misidentified the data directory.

/home/travis/.rvm/gems/ruby-2.3.3/bundler/gems/inspec-78c2a55945cb/lib/resources/postgres_conf.rb:29:in `dirname': can't convert Inspec::Attribute::DEFAULT_ATTRIBUTE to String (Inspec::Attribute::DEFAULT_ATTRIBUTE#to_str gives Inspec::Attribute::DEFAULT_ATTRIBUTE) (TypeError)
```