### PR TITLE
allows patch levels (ie 9.5.14)

### DIFF
--- a/controls/postgres_spec.rb
+++ b/controls/postgres_spec.rb
@@ -115,7 +115,7 @@ control 'postgres-02' do
   title 'Use stable postgresql version'
   desc 'Use only community or commercially supported version of the PostgreSQL software. Do not use RC, DEVEL oder BETA versions in a production environment.'
   describe command('psql -V') do
-    its('stdout') { should match(/\b((9\.[3-6]|\b10\.5)(\.\d*)*)$/) }
+    its('stdout') { should match(/^psql\s\(PostgreSQL\)\s(9\.[3-6]|10\.5).*/) }
   end
   describe command('psql -V') do
     its('stdout') { should_not match(/RC/) }

--- a/controls/postgres_spec.rb
+++ b/controls/postgres_spec.rb
@@ -115,7 +115,7 @@ control 'postgres-02' do
   title 'Use stable postgresql version'
   desc 'Use only community or commercially supported version of the PostgreSQL software. Do not use RC, DEVEL oder BETA versions in a production environment.'
   describe command('psql -V') do
-    its('stdout') { should match(/(\b9\.[3-6]|\b10\.5)\.[0-9]+$/) }
+    its('stdout') { should match(/\b((9\.[3-6]|\b10\.5)(\.\d*)*)$/) }
   end
   describe command('psql -V') do
     its('stdout') { should_not match(/RC/) }

--- a/controls/postgres_spec.rb
+++ b/controls/postgres_spec.rb
@@ -115,7 +115,7 @@ control 'postgres-02' do
   title 'Use stable postgresql version'
   desc 'Use only community or commercially supported version of the PostgreSQL software. Do not use RC, DEVEL oder BETA versions in a production environment.'
   describe command('psql -V') do
-    its('stdout') { should match(/\b9\.[3-6]$|\b10\.5$/) }
+    its('stdout') { should match(/(\b9\.[3-6]|\b10\.5)\.[0-9]+$/) }
   end
   describe command('psql -V') do
     its('stdout') { should_not match(/RC/) }


### PR DESCRIPTION
This broke after #25  went in 

```
  ×  postgres-02: Use stable postgresql version (1 failed)
     ×  Command psql -V stdout should match /\b9\.[3-6]$|\b10\.5$/
     expected "psql (PostgreSQL) 9.5.14\n" to match /\b9\.[3-6]$|\b10\.5$/
     Diff:
     @@ -1,2 +1,2 @@
     -/\b9\.[3-6]$|\b10\.5$/
     +psql (PostgreSQL) 9.5.14
```

Using this PR:

```
  ✔  postgres-02: Use stable postgresql version
     ✔  Command psql -V stdout should match /(\b9\.[3-6]|\b10\.5)\.[0-9]+$/
     ✔  Command psql -V stdout should not match /RC/
     ✔  Command psql -V stdout should not match /DEVEL/
     ✔  Command psql -V stdout should not match /BETA/
```

See http://rubular.com/r/2aiU6kIEG6