### PR TITLE
Bump version to 2.0.4 and switch to inspec 3 for check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 **/.tmp
 Gemfile.lock
 Berksfile.lock
+inspec.lock
 nbproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
----
+sudo: false
 language: ruby
 cache: bundler
+
 rvm:
-  - 2.3.3
+  - 2.4.1
 
 bundler_args: --without integration
 script: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [2.0.4](https://github.com/dev-sec/postgres-baseline/tree/2.0.4) (2019-05-08)
+[Full Changelog](https://github.com/dev-sec/postgres-baseline/compare/2.0.3...2.0.4)
+
+**Closed issues:**
+
+- Update supported versions [\#23](https://github.com/dev-sec/postgres-baseline/issues/23)
+
+**Merged pull requests:**
+
+- Update issue templates [\#29](https://github.com/dev-sec/postgres-baseline/pull/29) ([rndmh3ro](https://github.com/rndmh3ro))
+- Update baseline title [\#27](https://github.com/dev-sec/postgres-baseline/pull/27) ([chris-rock](https://github.com/chris-rock))
+- allows patch levels \(ie 9.5.14\) [\#26](https://github.com/dev-sec/postgres-baseline/pull/26) ([ojongerius](https://github.com/ojongerius))
+- Fix \#23 - update supported versions [\#25](https://github.com/dev-sec/postgres-baseline/pull/25) ([pmav99](https://github.com/pmav99))
+
 ## [2.0.3](https://github.com/dev-sec/postgres-baseline/tree/2.0.3) (2017-12-01)
 [Full Changelog](https://github.com/dev-sec/postgres-baseline/compare/2.0.2...2.0.3)
 
@@ -19,6 +33,7 @@
 
 **Merged pull requests:**
 
+- update rubocop dependency [\#28](https://github.com/dev-sec/postgres-baseline/pull/28) ([chris-rock](https://github.com/chris-rock))
 - update metadata [\#19](https://github.com/dev-sec/postgres-baseline/pull/19) ([chris-rock](https://github.com/chris-rock))
 - restrict ruby testing to version 2.3.3 and update gemfile [\#18](https://github.com/dev-sec/postgres-baseline/pull/18) ([atomic111](https://github.com/atomic111))
 - adjust the service for each os type and correct the control 10 [\#16](https://github.com/dev-sec/postgres-baseline/pull/16) ([atomic111](https://github.com/atomic111))

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'highline', '~> 2.0.2'
-gem 'inspec-bin', '~> 4'
+gem 'inspec', '~> 3'
 gem 'rack', '~> 2.0.7'
 gem 'rake', '~> 12.3.2'
 gem 'rubocop', '~> 0.68.1'

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'highline', '~> 1.6.0'
-gem 'inspec', '~> 2'
-gem 'rack', '1.6.4'
-gem 'rake'
-gem 'rubocop', '~> 0.59.0'
+gem 'highline', '~> 2.0.2'
+gem 'inspec-bin', '~> 4'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -20,23 +20,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts " * Checking profile with InSpec version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'postgres-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test-suite for best-practice postgres hardening
-version: 2.0.3
+version: 2.0.4
 supports:
 - os-family: unix


### PR DESCRIPTION
Switched to inspec check without CLI.

Rakefile only loading the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise I was getting:
```
$ bundle exec rake changelog
 * Generating changelog for version 2.0.4
Can't detect user and name from first parameter: 'changelog' -> exit'
rake aborted!...
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys.
/Users/apop/git/postgres-baseline/Rakefile:45:in `block in <top (required)>'
/opt/chefdk/embedded/bin/bundle:23:in `load'
/opt/chefdk/embedded/bin/bundle:23:in `<main>'
Tasks: TOP => changelog
(See full trace by running task with --trace)
```
