### PR TITLE
use input instead of attribute

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -6,6 +6,7 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test-suite for best-practice postgres hardening
+inspec_version: '>= 4.6.3'
 version: 3.0.1
 supports:
     - os-family: unix


### PR DESCRIPTION
In the last versions of Inspec and cinc-auditor, attribute is deprecated and input should be used.

https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper/