### PR TITLE
Fix #52: Update supported versions

### DIFF
--- a/controls/postgres_spec.rb
+++ b/controls/postgres_spec.rb
@@ -50,7 +50,7 @@ control 'postgres-02' do
   title 'Use stable postgresql version'
   desc 'Use only community or commercially supported version of the PostgreSQL software (https://www.postgresql.org/support/versioning/). Do not use RC, DEVEL or BETA versions in a production environment.'
   describe command('psql -V') do
-    its('stdout') { should match /^psql\s\(PostgreSQL\)\s(9.6|10|11|12|13).*/ }
+    its('stdout') { should match /^psql\s\(PostgreSQL\)\s(12|13|14|15|16).*/ }
   end
   describe command('psql -V') do
     its('stdout') { should_not match /RC/ }


### PR DESCRIPTION
Updated PostgreSQL supported versions based on https://endoflife.date/postgresql.