### PR TITLE
Fix #17: Checking postgresql status on Ubuntu

### DIFF
--- a/controls/postgres_spec.rb
+++ b/controls/postgres_spec.rb
@@ -38,10 +38,16 @@ control 'postgres-01' do
   impact 1.0
   title 'Postgresql should be running'
   desc 'Postgresql should be running.'
-  describe service(postgres.service) do
-    it { should be_installed }
-    it { should be_running }
-    it { should be_enabled }
+  if os[:name] == "ubuntu"
+    describe command('/etc/init.d/postgresql status') do
+      its('stdout') { should include 'active' }
+    end
+  else
+    describe service(postgres.service) do
+      it { should be_installed }
+      it { should be_running }
+      it { should be_enabled }
+    end
   end
 end
 


### PR DESCRIPTION
In the Ubuntu operating system, the name of the PostgreSQL service is `postgresql`.